### PR TITLE
Fix experiment manager placeholder

### DIFF
--- a/src/experiment_manager/resource/experiment_manager
+++ b/src/experiment_manager/resource/experiment_manager
@@ -1,1 +1,1 @@
-resource placeholder
+experiment_manager


### PR DESCRIPTION
## Summary
- fix `experiment_manager` resource file placeholder

## Testing
- `pytest -q src/experiment_manager/test` *(fails: ModuleNotFoundError: No module named 'ament_copyright')*


------
https://chatgpt.com/codex/tasks/task_e_6848a666fb488328bce957e6be5bbeea