### PR TITLE
Fix deactivate transition trigger

### DIFF
--- a/src/experiment_manager/experiment_manager/experiment_manager_node.py
+++ b/src/experiment_manager/experiment_manager/experiment_manager_node.py
@@ -114,7 +114,7 @@ class ExperimentManager(LifecycleNode):
     # Helper to trigger deactivate transition
     def trigger_deactivate(self):
         self.get_logger().info('Requesting deactivate transition')
-        self.trigger_transition(Transition.TRANSITION_DEACTIVATE)
+        super().trigger_deactivate()
 
 
 def main(args=None):


### PR DESCRIPTION
## Summary
- use LifecycleNode's `trigger_deactivate()` helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ament_copyright')*

------
https://chatgpt.com/codex/tasks/task_e_6848a65c03f0832896a093ae95d0f5a8