### PR TITLE
Fix ROS2 experiment manager discovery

### DIFF
--- a/src/experiment_manager/resource/experiment_manager
+++ b/src/experiment_manager/resource/experiment_manager
@@ -1,1 +1,0 @@
-experiment_manager


### PR DESCRIPTION
## Summary
- clear `experiment_manager` resource file so ROS2 can find the package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ament_copyright')*

------
https://chatgpt.com/codex/tasks/task_e_6849862fb3408328bc15c254cafb8a94