### PR TITLE
Add Experiment Manager usage README

### DIFF
--- a/src/experiment_manager/README.md
+++ b/src/experiment_manager/README.md
@@ -1,0 +1,34 @@
+# Experiment Manager
+
+This package contains a ROS 2 lifecycle node that orchestrates experiment runs in the greenhouse.
+
+## Quick start
+
+1. Build the workspace:
+
+```bash
+colcon build
+```
+
+2. Source the environment:
+
+```bash
+source install/setup.bash
+```
+
+3. Launch the node:
+
+```bash
+ros2 run experiment_manager experiment_manager
+```
+
+## Parameters
+
+- **ros2_launch_cmd** (string, optional)
+  - Command executed for each experiment. Defaults to `ros2 launch roverrobotics_driver experiments_launch.py`.
+  - The referenced launch file accepts parameters such as `experiment_type`, `use_imu`, `n_plants` and `infected_plants_list_str`.
+
+## Prerequisites
+
+- ROS 2 installed (tested with Humble).
+- Required packages, including `roverrobotics_driver`, must be built in this workspace.


### PR DESCRIPTION
## Summary
- document how to build and run the experiment_manager node

## Testing
- `pytest -q` *(fails: No module named 'ament_flake8')*

------
https://chatgpt.com/codex/tasks/task_e_6849863998cc83289a1a044e0c327da0