### PR TITLE
Document lint test dependencies

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -282,3 +282,15 @@ We also recommend these ROS2 tutorial playlists from [Articulated Robotics](http
 
 [(2) Various ROS Tutorials from simulation to building a robot to software](https://www.youtube.com/playlist?list=PLunhqkrRNRhYAffV8JDiFOatQXuU-NnxT)
 
+
+## Running Tests
+To run lint tests you need to install some `ament` packages that are not part of a default ROS 2 installation. Install them with:
+```bash
+sudo apt install python3-ament-copyright \
+                 python3-ament-flake8 \
+                 python3-ament-pep257
+```
+Then execute the tests from your workspace:
+```bash
+colcon test
+```


### PR DESCRIPTION
## Summary
- document how to run tests and install ament lint dependencies

## Testing
- `colcon test` *(fails: package not built)*

------
https://chatgpt.com/codex/tasks/task_e_6849863982dc8328845e7bde9ac8f637